### PR TITLE
Added Check for Encounter Difficulty To Find Non-Savage Fights

### DIFF
--- a/src/Prima.Stable/Models/FFLogs/LogInfo.cs
+++ b/src/Prima.Stable/Models/FFLogs/LogInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Security.Policy;
 
 namespace Prima.Stable.Models.FFLogs
 {
@@ -35,6 +36,9 @@ namespace Prima.Stable.Models.FFLogs
 
                         [JsonProperty("friendlyPlayers")]
                         public int[] FriendlyPlayers { get; set; }
+
+                        [JsonProperty("difficulty")]
+                        public int? Difficulty { get; set; }
                     }
 
                     public class Master

--- a/src/Prima.Stable/Models/FFLogs/LogInfo.cs
+++ b/src/Prima.Stable/Models/FFLogs/LogInfo.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Security.Policy;
 
 namespace Prima.Stable.Models.FFLogs
 {

--- a/src/Prima.Stable/Modules/BozjaExtraModule.cs
+++ b/src/Prima.Stable/Modules/BozjaExtraModule.cs
@@ -307,6 +307,12 @@ namespace Prima.Stable.Modules
             var addedAny = false;
             foreach (var encounter in encounters)
             {
+                if (encounter.Difficulty == 100)
+                {
+                    Log.Error("Encounter {Encounter} does not appear to be a Savage encounter", encounter.Name);
+                    await ReplyAsync("Encounter does not appear to be a Savage encounter");
+                    continue;
+                }
                 var roleName = encounter.Name;
                 if (roleName == "The Queen's Guard")
                     roleName = "Queen's Guard";

--- a/src/Prima.Stable/Modules/BozjaExtraModule.cs
+++ b/src/Prima.Stable/Modules/BozjaExtraModule.cs
@@ -310,7 +310,6 @@ namespace Prima.Stable.Modules
                 if (encounter.Difficulty == 100)
                 {
                     Log.Error("Encounter {Encounter} does not appear to be a Savage encounter", encounter.Name);
-                    await ReplyAsync("Encounter does not appear to be a Savage encounter");
                     continue;
                 }
                 var roleName = encounter.Name;

--- a/src/Prima/Game/FFXIV/FFLogs/FFLogsUtils.cs
+++ b/src/Prima/Game/FFXIV/FFLogs/FFLogsUtils.cs
@@ -20,6 +20,7 @@ namespace Prima.Game.FFXIV.FFLogs
                 kill
                 name
                 friendlyPlayers
+                difficulty
             }}
             masterData {{
                 actors {{


### PR DESCRIPTION
Difficulty property appears to be 100 for DRN fights, 101 for DRS fights. Added check to screen logs for difficulty to keep DRN encounters from being used for clear roles