### PR TITLE
Assign host roles an hour before their event begins

### DIFF
--- a/src/Prima.Application/Scheduling/CheckBozjaEventsJob.cs
+++ b/src/Prima.Application/Scheduling/CheckBozjaEventsJob.cs
@@ -39,11 +39,48 @@ public class CheckBozjaEventsJob : CheckEventChannelJob
         
         var guild = Client.GetGuild(SpecialGuilds.CrystalExploratoryMissions);
         
-        var success = await AssignHostRole(guild);
+        var success = await AssignHostPreparingRole(guild);
         if (!success) return;
 
         await NotifyHost("The Bozja/Zadnor event you scheduled is set to begin in 30 minutes!");
         await NotifyMembers($"The Bozja/Zadnor event you reacted to (hosted by {HostUser?.Nickname ?? HostUser?.Username}) is beginning in 30 minutes!");
+    }
+    
+    protected override async Task OnMatch2()
+    {
+        var guildConfig = Db.Guilds.FirstOrDefault(g => g.Id == SpecialGuilds.CrystalExploratoryMissions);
+        if (guildConfig == null)
+        {
+            Logger.LogError("No guild configuration found for the default guild!");
+            return;
+        }
+        
+        var guild = Client.GetGuild(SpecialGuilds.CrystalExploratoryMissions);
+        
+        var success = await AssignHostRole(guild);
+        if (!success) return;
+
+        await NotifyHost("The Bozja/Zadnor event you scheduled is set to begin in 60 minutes! Your role permissions have been updated.");
+    }
+    
+    private async Task<bool> AssignHostPreparingRole(SocketGuild guild)
+    {
+        var preparing = guild.GetRole(RunHostData.PreparingForEventRoleId);
+
+        Logger.LogInformation("Assigning preparing role...");
+        if (HostUser == null || HostUser.HasRole(preparing)) return false;
+
+        try
+        {
+            await HostUser.AddRoleAsync(preparing);
+            await Db.AddTimedRole(preparing.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(1));
+            return true;
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Failed to add host role to {User}!", HostUser?.ToString() ?? "null");
+            return false;
+        }
     }
     
     private async Task<bool> AssignHostRole(SocketGuild guild)
@@ -57,13 +94,13 @@ public class CheckBozjaEventsJob : CheckEventChannelJob
         try
         {
             await HostUser.AddRolesAsync(new[] { currentHost, runPinner });
-            await Db.AddTimedRole(currentHost.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(4.5));
-            await Db.AddTimedRole(runPinner.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(4.5));
+            await Db.AddTimedRole(currentHost.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(5));
+            await Db.AddTimedRole(runPinner.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(5));
             return true;
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "Failed to add host role to {User}!", currentHost?.ToString() ?? "null");
+            Logger.LogError(e, "Failed to add host role to {User}!", HostUser?.ToString() ?? "null");
             return false;
         }
     }

--- a/src/Prima.Application/Scheduling/CheckCastrumEventsJob.cs
+++ b/src/Prima.Application/Scheduling/CheckCastrumEventsJob.cs
@@ -39,11 +39,48 @@ public class CheckCastrumEventsJob : CheckEventChannelJob
         
         var guild = Client.GetGuild(SpecialGuilds.CrystalExploratoryMissions);
         
-        var success = await AssignHostRole(guild);
+        var success = await AssignHostPreparingRole(guild);
         if (!success) return;
 
         await NotifyHost("The Castrum run you scheduled is set to begin in 30 minutes!");
         await NotifyMembers($"The Castrum run you reacted to (hosted by {HostUser?.Nickname ?? HostUser?.Username}) is beginning in 30 minutes!");
+    }
+    
+    protected override async Task OnMatch2()
+    {
+        var guildConfig = Db.Guilds.FirstOrDefault(g => g.Id == SpecialGuilds.CrystalExploratoryMissions);
+        if (guildConfig == null)
+        {
+            Logger.LogError("No guild configuration found for the default guild!");
+            return;
+        }
+        
+        var guild = Client.GetGuild(SpecialGuilds.CrystalExploratoryMissions);
+        
+        var success = await AssignHostRole(guild);
+        if (!success) return;
+
+        await NotifyHost("The Castrum run you scheduled is set to begin in 60 minutes! Your role permissions have been updated.");
+    }
+    
+    private async Task<bool> AssignHostPreparingRole(SocketGuild guild)
+    {
+        var preparing = guild.GetRole(RunHostData.PreparingForEventRoleId);
+
+        Logger.LogInformation("Assigning preparing role...");
+        if (HostUser == null || HostUser.HasRole(preparing)) return false;
+
+        try
+        {
+            await HostUser.AddRoleAsync(preparing);
+            await Db.AddTimedRole(preparing.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(1));
+            return true;
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Failed to add host role to {User}!", HostUser?.ToString() ?? "null");
+            return false;
+        }
     }
     
     private async Task<bool> AssignHostRole(SocketGuild guild)
@@ -57,13 +94,13 @@ public class CheckCastrumEventsJob : CheckEventChannelJob
         try
         {
             await HostUser.AddRolesAsync(new[] { currentHost, runPinner });
-            await Db.AddTimedRole(currentHost.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(4.5));
-            await Db.AddTimedRole(runPinner.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(4.5));
+            await Db.AddTimedRole(currentHost.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(5));
+            await Db.AddTimedRole(runPinner.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(5));
             return true;
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "Failed to add host role to {User}!", currentHost?.ToString() ?? "null");
+            Logger.LogError(e, "Failed to add host role to {User}!", HostUser?.ToString() ?? "null");
             return false;
         }
     }

--- a/src/Prima.Application/Scheduling/CheckDelubrumSavageEventsJob.cs
+++ b/src/Prima.Application/Scheduling/CheckDelubrumSavageEventsJob.cs
@@ -8,7 +8,8 @@ namespace Prima.Application.Scheduling;
 
 public class CheckDelubrumSavageEventsJob : CheckEventChannelJob
 {
-    public CheckDelubrumSavageEventsJob(ILogger<CheckDelubrumSavageEventsJob> logger, DiscordSocketClient client, IDbService db) : base(logger, client, db)
+    public CheckDelubrumSavageEventsJob(ILogger<CheckDelubrumSavageEventsJob> logger, DiscordSocketClient client,
+        IDbService db) : base(logger, client, db)
     {
     }
 
@@ -36,16 +37,34 @@ public class CheckDelubrumSavageEventsJob : CheckEventChannelJob
             Logger.LogError("No guild configuration found for the default guild!");
             return;
         }
-        
+
         var guild = Client.GetGuild(SpecialGuilds.CrystalExploratoryMissions);
-        
+
+        var success = await AssignHostPreparingRole(guild);
+        if (!success) return;
+
+        await NotifyHost("The Delubrum Reginae (Savage) run you scheduled is set to begin in 30 minutes!");
+        await NotifyMembers(
+            $"The Delubrum Reginae (Savage) run you reacted to (hosted by {HostUser?.Nickname ?? HostUser?.Username}) is beginning in 30 minutes!");
+    }
+
+    protected override async Task OnMatch2()
+    {
+        var guildConfig = Db.Guilds.FirstOrDefault(g => g.Id == SpecialGuilds.CrystalExploratoryMissions);
+        if (guildConfig == null)
+        {
+            Logger.LogError("No guild configuration found for the default guild!");
+            return;
+        }
+
+        var guild = Client.GetGuild(SpecialGuilds.CrystalExploratoryMissions);
+
         var success = await AssignHostRole(guild);
         if (!success) return;
 
         await AssignExecutorRole(guild);
-        await NotifyMembers($"The Delubrum Reginae (Savage) run you reacted to (hosted by {HostUser?.Nickname ?? HostUser?.Username}) is beginning in 30 minutes!");
         await NotifyHost(
-            "You have been given the Delubrum Host role for 4 1/2 hours!\n" +
+            "You have been given the Delubrum Host role for 5 hours!\n" +
             "You can now use the command `~setroler @User` to give them access to the progression " +
             "role commands `~addprogrole @User Role Name` and `~removeprogrole @User Role Name`!\n" +
             "You can also modify multiple users at once by using `~addprogrole @User1 @User2 Role Name`.\n\n" +
@@ -55,7 +74,27 @@ public class CheckDelubrumSavageEventsJob : CheckEventChannelJob
             "▫️ Trinity Avowed Progression\n" +
             "▫️ The Queen Progression");
     }
-    
+
+    private async Task<bool> AssignHostPreparingRole(SocketGuild guild)
+    {
+        var preparing = guild.GetRole(RunHostData.PreparingForEventRoleId);
+
+        Logger.LogInformation("Assigning preparing role...");
+        if (HostUser == null || HostUser.HasRole(preparing)) return false;
+
+        try
+        {
+            await HostUser.AddRoleAsync(preparing);
+            await Db.AddTimedRole(preparing.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(1));
+            return true;
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Failed to add preparing role to {User}!", HostUser?.ToString() ?? "null");
+            return false;
+        }
+    }
+
     private async Task<bool> AssignHostRole(SocketGuild guild)
     {
         var currentHost = guild.GetRole(RunHostData.RoleId);
@@ -67,24 +106,24 @@ public class CheckDelubrumSavageEventsJob : CheckEventChannelJob
         try
         {
             await HostUser.AddRolesAsync(new[] { currentHost, runPinner });
-            await Db.AddTimedRole(currentHost.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(4.5));
-            await Db.AddTimedRole(runPinner.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(4.5));
+            await Db.AddTimedRole(currentHost.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(5));
+            await Db.AddTimedRole(runPinner.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(5));
             return true;
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "Failed to add host role to {User}!", currentHost?.ToString() ?? "null");
+            Logger.LogError(e, "Failed to add host role to {User}!", HostUser?.ToString() ?? "null");
             return false;
         }
     }
-    
+
     private async Task AssignExecutorRole(SocketGuild guild)
     {
         var executor = guild.GetRole(DelubrumProgressionRoles.Executor);
-        
+
         if (HostUser == null || HostUser.HasRole(executor)) return;
-        
+
         await HostUser.AddRoleAsync(executor);
-        await Db.AddTimedRole(executor.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(4.5));
+        await Db.AddTimedRole(executor.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(5));
     }
 }

--- a/src/Prima.Application/Scheduling/CheckEventChannelJob.cs
+++ b/src/Prima.Application/Scheduling/CheckEventChannelJob.cs
@@ -40,6 +40,7 @@ public abstract class CheckEventChannelJob : IJob
             }
             
             await CheckRuns(guild, channelId, 30, OnMatch);
+            await CheckRuns(guild, channelId, 60, OnMatch2);
         }
         catch (Exception e)
         {
@@ -52,6 +53,11 @@ public abstract class CheckEventChannelJob : IJob
     protected abstract Task<ulong> GetChannelId();
 
     protected abstract Task OnMatch();
+
+    protected virtual Task OnMatch2()
+    {
+        return Task.CompletedTask;
+    }
     
     protected async Task NotifyHost(string message)
     {

--- a/src/Prima.Application/Scheduling/CheckSocialEventsJob.cs
+++ b/src/Prima.Application/Scheduling/CheckSocialEventsJob.cs
@@ -8,7 +8,8 @@ namespace Prima.Application.Scheduling;
 
 public class CheckSocialEventsJob : CheckEventChannelJob
 {
-    public CheckSocialEventsJob(ILogger<CheckSocialEventsJob> logger, DiscordSocketClient client, IDbService db) : base(logger, client, db)
+    public CheckSocialEventsJob(ILogger<CheckSocialEventsJob> logger, DiscordSocketClient client, IDbService db) : base(
+        logger, client, db)
     {
     }
 
@@ -36,16 +37,54 @@ public class CheckSocialEventsJob : CheckEventChannelJob
             Logger.LogError("No guild configuration found for the default guild!");
             return;
         }
-        
+
         var guild = Client.GetGuild(SpecialGuilds.CrystalExploratoryMissions);
-        
-        var success = await AssignSocialHostRole(guild);
+
+        var success = await AssignSocialHostPreparingRole(guild);
         if (!success) return;
 
         await NotifyHost("The event you scheduled is set to begin in 30 minutes!");
-        await NotifyMembers($"The event you reacted to (hosted by {HostUser?.Nickname ?? HostUser?.Username}) is beginning in 30 minutes!");
+        await NotifyMembers(
+            $"The event you reacted to (hosted by {HostUser?.Nickname ?? HostUser?.Username}) is beginning in 30 minutes!");
     }
-    
+
+    protected override async Task OnMatch2()
+    {
+        var guildConfig = Db.Guilds.FirstOrDefault(g => g.Id == SpecialGuilds.CrystalExploratoryMissions);
+        if (guildConfig == null)
+        {
+            Logger.LogError("No guild configuration found for the default guild!");
+            return;
+        }
+
+        var guild = Client.GetGuild(SpecialGuilds.CrystalExploratoryMissions);
+
+        var success = await AssignSocialHostRole(guild);
+        if (!success) return;
+
+        await NotifyHost("The event you scheduled is set to begin in 60 minutes! Your role permissions have been updated.");
+    }
+
+    private async Task<bool> AssignSocialHostPreparingRole(SocketGuild guild)
+    {
+        var preparing = guild.GetRole(RunHostData.PreparingForEventRoleId);
+
+        Logger.LogInformation("Assigning preparing role...");
+        if (HostUser == null || HostUser.HasRole(preparing)) return false;
+
+        try
+        {
+            await HostUser.AddRoleAsync(preparing);
+            await Db.AddTimedRole(preparing.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(1));
+            return true;
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Failed to add preparing role to {User}!", HostUser?.ToString() ?? "null");
+            return false;
+        }
+    }
+
     private async Task<bool> AssignSocialHostRole(SocketGuild guild)
     {
         var socialHost = guild.GetRole(RunHostData.SocialHostRoleId);
@@ -55,12 +94,12 @@ public class CheckSocialEventsJob : CheckEventChannelJob
 
         try
         {
-            await Db.AddTimedRole(socialHost.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(4.5));
+            await Db.AddTimedRole(socialHost.Id, guild.Id, HostUser.Id, DateTime.UtcNow.AddHours(5));
             return true;
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "Failed to add host role to {User}!", socialHost?.ToString() ?? "null");
+            Logger.LogError(e, "Failed to add host role to {User}!", HostUser?.ToString() ?? "null");
             return false;
         }
     }

--- a/src/Prima/Resources/RunHostData.cs
+++ b/src/Prima/Resources/RunHostData.cs
@@ -14,6 +14,12 @@
         public const ulong PinnerRoleId = 838109848867569695;
 #endif
 
+#if DEBUG
+        public const ulong PreparingForEventRoleId = 1069391471322607636;
+#else
+        public const ulong PreparingForEventRoleId = 1069387588152082472;
+#endif
+
         public const ulong SocialHostRoleId = 845217720017747970;
     }
 }


### PR DESCRIPTION
Roles are accordingly assigned for 5 hours, and a new "preparing for event" role has been added as a flag to check for the new 1h condition (the existing roles were used for the 30m condition).