### PR TITLE
Crosspost regular output channel messages

### DIFF
--- a/src/Prima.Application/IUserMessageExtensions.cs
+++ b/src/Prima.Application/IUserMessageExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Discord;
+using Microsoft.Extensions.Logging;
+
+namespace Prima.Application;
+
+public static class IUserMessageExtensions
+{
+    public static async Task CrosspostSafeAsync(
+        this IUserMessage message,
+        ILogger logger,
+        RequestOptions? options = null)
+    {
+        try
+        {
+            await message.CrosspostAsync(options);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to crosspost message");
+        }
+    }
+}


### PR DESCRIPTION
Adds crossposting on the regular output channel on initial announcements only. This channel is frequently cleared for sorting, or else we could also crosspost on updates. If this isn't sufficient, the actual announcement channels may need to be made public.