### PR TITLE
Implement fight-specific parsing rules and tests

### DIFF
--- a/src/Prima.Application/Commands/FFXIV/DelubrumReginae/DRRunCommands.cs
+++ b/src/Prima.Application/Commands/FFXIV/DelubrumReginae/DRRunCommands.cs
@@ -5,6 +5,7 @@ using NetStone;
 using Prima.DiscordNet;
 using Prima.DiscordNet.Attributes;
 using Prima.Game.FFXIV.FFLogs;
+using Prima.Game.FFXIV.FFLogs.Rules;
 using Prima.Models.FFLogs;
 using Prima.Resources;
 using Prima.Services;
@@ -224,7 +225,8 @@ public class DRRunCommands : ModuleBase<SocketCommandContext>
     public async Task ReadLog(string logLink)
     {
         var actorMapper = new CommandBatchActorMapper(_db, _lodestone, Context.Guild);
-        var logParsingResult = await _logParser.ReadLog(logLink, actorMapper);
+        var rules = new DelubrumReginaeSavageRules();
+        var logParsingResult = await _logParser.ReadLog(logLink, actorMapper, rules);
         switch (logParsingResult)
         {
             case LogParsingResult.Failure failure:

--- a/src/Prima.Tests/DelubrumReginaeSavageRulesTests.cs
+++ b/src/Prima.Tests/DelubrumReginaeSavageRulesTests.cs
@@ -1,0 +1,121 @@
+using System.Linq;
+using NUnit.Framework;
+using Prima.Game.FFXIV.FFLogs.Rules;
+using Prima.Resources;
+
+namespace Prima.Tests
+{
+    [TestFixture]
+    public class DelubrumReginaeSavageRulesTests
+    {
+        private DelubrumReginaeSavageRules _rules;
+
+        [SetUp]
+        public void Setup()
+        {
+            _rules = new DelubrumReginaeSavageRules();
+        }
+
+        [TestCase("Trinity Seeker", "Trinity Seeker Progression")]
+        [TestCase("The Queen's Guard", "Queen's Guard Progression")]
+        [TestCase("Queen's Guard", "Queen's Guard Progression")]
+        [TestCase("Trinity Avowed", "Trinity Avowed Progression")]
+        [TestCase("The Queen", "The Queen Progression")]
+        [TestCase("Unknown Boss", null)]
+        [TestCase("Random Encounter", null)]
+        public void GetProgressionRoleName_ReturnsExpectedRole(string encounterName, string expectedRole)
+        {
+            var result = _rules.GetProgressionRoleName(encounterName);
+            Assert.That(result, Is.EqualTo(expectedRole));
+        }
+
+        [Test]
+        public void GetKillRoleId_TrinitySeeker_ReturnsQueensGuard()
+        {
+            var result = _rules.GetKillRoleId("Trinity Seeker Progression");
+            var expectedRoleId = DelubrumProgressionRoles.Roles
+                .First(kvp => kvp.Value == "Queen's Guard Progression").Key;
+            Assert.That(result, Is.EqualTo(expectedRoleId));
+        }
+
+        [Test]
+        public void GetKillRoleId_QueensGuard_ReturnsTrinityAvowed()
+        {
+            var result = _rules.GetKillRoleId("Queen's Guard Progression");
+            var expectedRoleId = DelubrumProgressionRoles.Roles
+                .First(kvp => kvp.Value == "Trinity Avowed Progression").Key;
+            Assert.That(result, Is.EqualTo(expectedRoleId));
+        }
+
+        [Test]
+        public void GetKillRoleId_TrinityAvowed_ReturnsTheQueen()
+        {
+            var result = _rules.GetKillRoleId("Trinity Avowed Progression");
+            var expectedRoleId = DelubrumProgressionRoles.Roles
+                .First(kvp => kvp.Value == "The Queen Progression").Key;
+            Assert.That(result, Is.EqualTo(expectedRoleId));
+        }
+
+        [Test]
+        public void GetKillRoleId_TheQueen_ReturnsDRSCleared()
+        {
+            var result = _rules.GetKillRoleId("The Queen Progression");
+            Assert.That(result, Is.EqualTo(DelubrumProgressionRoles.ClearedDelubrumSavage));
+        }
+
+        [Test]
+        public void GetKillRoleId_InvalidRole_ReturnsZero()
+        {
+            var result = _rules.GetKillRoleId("Invalid Progression");
+            Assert.That(result, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void GetContingentRoleIds_QueenProgression_ReturnsAllProgressionRoles()
+        {
+            var queenRole = DelubrumProgressionRoles.Roles
+                .First(kvp => kvp.Value == "The Queen Progression").Key;
+            var contingentRoles = _rules.GetContingentRoleIds(queenRole).ToList();
+
+            // Should return all progression roles when at The Queen
+            var expectedRoles = DelubrumProgressionRoles.Roles
+                .Where(kvp => kvp.Value.EndsWith("Progression") && kvp.Value != "debug delub role")
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var expectedRole in expectedRoles)
+            {
+                Assert.That(contingentRoles, Does.Contain(expectedRole));
+            }
+        }
+
+        [Test]
+        public void GetContingentRoleIds_TrinitySeekerProgression_ReturnsSelfOnly()
+        {
+            var trinitySeekerRole = DelubrumProgressionRoles.Roles
+                .First(kvp => kvp.Value == "Trinity Seeker Progression").Key;
+            var contingentRoles = _rules.GetContingentRoleIds(trinitySeekerRole).ToList();
+
+            Assert.That(contingentRoles.Count, Is.EqualTo(1));
+            Assert.That(contingentRoles[0], Is.EqualTo(trinitySeekerRole));
+        }
+
+        [Test]
+        public void GetContingentRoleIds_InvalidRoleId_ReturnsEmpty()
+        {
+            var contingentRoles = _rules.GetContingentRoleIds(999999).ToList();
+            Assert.That(contingentRoles, Is.Empty);
+        }
+
+        [TestCase(100, false, Description = "Normal mode encounters should not be processed")]
+        [TestCase(101, true, Description = "Savage encounters should be processed")]
+        [TestCase(null, true, Description = "Null difficulty should be processed")]
+        [TestCase(0, true, Description = "Zero difficulty should be processed")]
+        [TestCase(99, true, Description = "Any non-100 difficulty should be processed")]
+        public void ShouldProcessEncounter_ReturnsExpectedResult(int? difficulty, bool expected)
+        {
+            var result = _rules.ShouldProcessEncounter(difficulty);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/Prima.Tests/LogParserServiceTests.cs
+++ b/src/Prima.Tests/LogParserServiceTests.cs
@@ -1,0 +1,266 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Prima.Game.FFXIV;
+using Prima.Game.FFXIV.FFLogs;
+using Prima.Game.FFXIV.FFLogs.Rules;
+using Prima.Models.FFLogs;
+using Prima.Resources;
+using Prima.Tests.Mocks;
+
+namespace Prima.Tests
+{
+    [TestFixture]
+    public class LogParserServiceTests
+    {
+        private LogParserService _service;
+        private MockFFLogsClient _mockFFLogsClient;
+        private MockBatchActorMapper _mockActorMapper;
+        private ILogParsingRules _logParsingRules;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockFFLogsClient = new MockFFLogsClient();
+            _service = new LogParserService(_mockFFLogsClient);
+            _mockActorMapper = new MockBatchActorMapper();
+            _logParsingRules = new DelubrumReginaeSavageRules();
+        }
+
+        [Test]
+        public async Task ReadLog_InvalidLogLink_ReturnsError()
+        {
+            var result = await _service.ReadLog("not-a-log-link", _mockActorMapper, _logParsingRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Failure>());
+            var failure = (LogParsingResult.Failure)result;
+            Assert.That(failure.ErrorMessage, Is.EqualTo("That doesn't look like a log link!"));
+        }
+
+        [Test]
+        public async Task ReadLog_PrivateLog_ReturnsError()
+        {
+            var testLog = CreatePrivateLog();
+            _mockFFLogsClient.SetupLog(testLog);
+
+            var result = await _service.ReadLog("https://www.fflogs.com/reports/abcde12345", _mockActorMapper,
+                _logParsingRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Failure>());
+            var failure = (LogParsingResult.Failure)result;
+            Assert.That(failure.ErrorMessage, Is.EqualTo("That log is private; please make it unlisted or public."));
+        }
+
+        [Test]
+        public async Task ReadLog_ValidDRSLog_UsesDefaultRules()
+        {
+            // Setup a valid DRS log
+            var testLog = CreateTestDRSLog();
+            _mockFFLogsClient.SetupLog(testLog);
+            _mockActorMapper.SetupUsers(new Dictionary<int, DiscordXIVUser>
+            {
+                { 1, new DiscordXIVUser { Name = "TestPlayer", World = "TestWorld", DiscordId = 12345 } },
+            });
+
+            var result = await _service.ReadLog("https://www.fflogs.com/reports/abcde12345", _mockActorMapper,
+                _logParsingRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Success>());
+            var success = (LogParsingResult.Success)result;
+            Assert.That(success.HasAnyChanges, Is.True);
+            Assert.That(success.RoleAssignments.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task ReadLog_WithCustomRules_UsesProvidedRules()
+        {
+            var testLog = CreateTestDRSLog();
+            _mockFFLogsClient.SetupLog(testLog);
+            _mockActorMapper.SetupUsers(new Dictionary<int, DiscordXIVUser>
+            {
+                { 1, new DiscordXIVUser { Name = "TestPlayer", World = "TestWorld", DiscordId = 12345 } },
+            });
+
+            var customRules = new DelubrumReginaeSavageRules();
+            var result = await _service.ReadLog("https://www.fflogs.com/reports/abcde12345", _mockActorMapper,
+                customRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Success>());
+            var success = (LogParsingResult.Success)result;
+            Assert.That(success.HasAnyChanges, Is.True);
+        }
+
+        [Test]
+        public async Task ReadLog_TrinitySeeker_AssignsCorrectRoles()
+        {
+            var testLog = CreateTestLogWithEncounter("Trinity Seeker", true, 101);
+            _mockFFLogsClient.SetupLog(testLog);
+            _mockActorMapper.SetupUsers(new Dictionary<int, DiscordXIVUser>
+            {
+                { 1, new DiscordXIVUser { Name = "TestPlayer", World = "TestWorld", DiscordId = 12345 } },
+            });
+
+            var result = await _service.ReadLog("https://www.fflogs.com/reports/abcde12345", _mockActorMapper,
+                _logParsingRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Success>());
+            var success = (LogParsingResult.Success)result;
+            Assert.That(success.RoleAssignments.Count, Is.EqualTo(1));
+
+            var assignment = success.RoleAssignments[0];
+            var roleActions = assignment.RoleActions;
+
+            // Should add Trinity Seeker Progression role
+            Assert.That(roleActions.Any(ra =>
+                ra.ActionType == LogParsingResult.RoleActionType.Add &&
+                ra.RoleId == DelubrumProgressionRoles.Roles.First(kvp => kvp.Value == "Trinity Seeker Progression")
+                    .Key));
+
+            // Should add Queen's Guard Progression role (kill role)
+            Assert.That(roleActions.Any(ra =>
+                ra.ActionType == LogParsingResult.RoleActionType.Add &&
+                ra.RoleId == DelubrumProgressionRoles.Roles.First(kvp => kvp.Value == "Queen's Guard Progression")
+                    .Key));
+        }
+
+        [Test]
+        public async Task ReadLog_TheQueenKill_RemovesProgressionRolesAndAddsClear()
+        {
+            var testLog = CreateTestLogWithEncounter("The Queen", true, 101);
+            _mockFFLogsClient.SetupLog(testLog);
+            _mockActorMapper.SetupUsers(new Dictionary<int, DiscordXIVUser>
+            {
+                { 1, new DiscordXIVUser { Name = "TestPlayer", World = "TestWorld", DiscordId = 12345 } },
+            });
+
+            var result = await _service.ReadLog("https://www.fflogs.com/reports/abcde12345", _mockActorMapper,
+                _logParsingRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Success>());
+            var success = (LogParsingResult.Success)result;
+
+            var assignment = success.RoleAssignments[0];
+            var roleActions = assignment.RoleActions;
+
+            // Should have remove actions for all progression roles
+            var removeActions = roleActions.Where(ra => ra.ActionType == LogParsingResult.RoleActionType.Remove)
+                .ToList();
+            Assert.That(removeActions.Count, Is.GreaterThan(0));
+
+            // Should add DRS Cleared role
+            Assert.That(roleActions.Any(ra =>
+                ra.ActionType == LogParsingResult.RoleActionType.Add &&
+                ra.RoleId == DelubrumProgressionRoles.ClearedDelubrumSavage));
+        }
+
+        [Test]
+        public async Task ReadLog_NormalMode_SkipsEncounter()
+        {
+            var testLog = CreateTestLogWithEncounter("Trinity Seeker", true, 100); // difficulty 100 = normal
+            _mockFFLogsClient.SetupLog(testLog);
+            _mockActorMapper.SetupUsers(new Dictionary<int, DiscordXIVUser>
+            {
+                { 1, new DiscordXIVUser { Name = "TestPlayer", World = "TestWorld", DiscordId = 12345 } },
+            });
+
+            var result = await _service.ReadLog("https://www.fflogs.com/reports/abcde12345", _mockActorMapper,
+                _logParsingRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Success>());
+            var success = (LogParsingResult.Success)result;
+            Assert.That(success.HasAnyChanges, Is.False);
+        }
+
+        [Test]
+        public async Task ReadLog_UnknownEncounter_SkipsEncounter()
+        {
+            var testLog = CreateTestLogWithEncounter("Unknown Boss", true, 101);
+            _mockFFLogsClient.SetupLog(testLog);
+            _mockActorMapper.SetupUsers(new Dictionary<int, DiscordXIVUser>
+            {
+                { 1, new DiscordXIVUser { Name = "TestPlayer", World = "TestWorld", DiscordId = 12345 } },
+            });
+
+            var result = await _service.ReadLog("https://www.fflogs.com/reports/abcde12345", _mockActorMapper,
+                _logParsingRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Success>());
+            var success = (LogParsingResult.Success)result;
+            Assert.That(success.HasAnyChanges, Is.False);
+        }
+
+        [Test]
+        public async Task ReadLog_MissedUsers_ReportsInResult()
+        {
+            var testLog = CreateTestDRSLog();
+            _mockFFLogsClient.SetupLog(testLog);
+            _mockActorMapper.SetupUsers(new Dictionary<int, DiscordXIVUser>()); // No users mapped
+
+            var result = await _service.ReadLog("https://www.fflogs.com/reports/abcde12345", _mockActorMapper,
+                _logParsingRules);
+
+            Assert.That(result, Is.InstanceOf<LogParsingResult.Success>());
+            var success = (LogParsingResult.Success)result;
+            Assert.That(success.MissedUsers.Count, Is.EqualTo(1));
+            Assert.That(success.MissedUsers[0].Name, Is.EqualTo("TestPlayer"));
+        }
+
+        private static LogInfo CreateTestDRSLog()
+        {
+            return CreateTestLogWithEncounter("Trinity Seeker", true, 101);
+        }
+
+        private static LogInfo CreateTestLogWithEncounter(string encounterName, bool? kill, int? difficulty)
+        {
+            return new LogInfo
+            {
+                Content = new LogInfo.ReportDataWrapper
+                {
+                    Data = new LogInfo.ReportDataWrapper.ReportData
+                    {
+                        ReportInfo = new LogInfo.ReportDataWrapper.ReportData.Report
+                        {
+                            Fights = new[]
+                            {
+                                new LogInfo.ReportDataWrapper.ReportData.Report.Fight
+                                {
+                                    Name = encounterName,
+                                    Kill = kill,
+                                    Difficulty = difficulty,
+                                    FriendlyPlayers = new[] { 1 },
+                                },
+                            },
+                            MasterData = new LogInfo.ReportDataWrapper.ReportData.Report.Master
+                            {
+                                Actors = new[]
+                                {
+                                    new LogInfo.ReportDataWrapper.ReportData.Report.Master.Actor
+                                    {
+                                        Id = 1,
+                                        Name = "TestPlayer",
+                                        Server = "TestWorld",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        private static LogInfo CreatePrivateLog()
+        {
+            return new LogInfo
+            {
+                Content = new LogInfo.ReportDataWrapper
+                {
+                    Data = new LogInfo.ReportDataWrapper.ReportData
+                    {
+                        ReportInfo = null,
+                    },
+                },
+            };
+        }
+    }
+}

--- a/src/Prima.Tests/Mocks/MockFFLogsClient.cs
+++ b/src/Prima.Tests/Mocks/MockFFLogsClient.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Prima.Game.FFXIV;
+using Prima.Game.FFXIV.FFLogs;
+using Prima.Models.FFLogs;
+
+namespace Prima.Tests.Mocks
+{
+    public class MockFFLogsClient : IFFLogsClient
+    {
+        private LogInfo _responseToReturn;
+
+        public void SetupLog(LogInfo logInfo)
+        {
+            _responseToReturn = logInfo;
+        }
+
+        public Task Initialize()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<T> MakeGraphQLRequest<T>(string query)
+        {
+            if (_responseToReturn != null && typeof(T) == typeof(LogInfo))
+            {
+                return Task.FromResult((T)(object)_responseToReturn);
+            }
+
+            return Task.FromResult(default(T));
+        }
+    }
+
+    public class MockBatchActorMapper : IBatchActorMapper
+    {
+        private Dictionary<int, DiscordXIVUser> _userMapping = new();
+
+        public void SetupUsers(Dictionary<int, DiscordXIVUser> userMapping)
+        {
+            _userMapping = userMapping;
+        }
+
+        public Task<Dictionary<int, DiscordXIVUser>> GetUsersFromActors(
+            IEnumerable<LogInfo.ReportDataWrapper.ReportData.Report.Master.Actor> actors)
+        {
+            return Task.FromResult(_userMapping);
+        }
+    }
+}

--- a/src/Prima/Game/FFXIV/FFLogs/ILogParserService.cs
+++ b/src/Prima/Game/FFXIV/FFLogs/ILogParserService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Prima.Game.FFXIV.FFLogs.Rules;
 using Prima.Models.FFLogs;
 
 namespace Prima.Game.FFXIV.FFLogs
@@ -6,11 +7,12 @@ namespace Prima.Game.FFXIV.FFLogs
     public interface ILogParserService
     {
         /// <summary>
-        /// Reads a fight log to compute progression role updates.
+        /// Reads a fight log to compute progression role updates using custom parsing rules.
         /// </summary>
         /// <param name="logLink">The FFLogs log link.</param>
         /// <param name="actorMapper">A helper to fetch users based on FFLogs actors.</param>
+        /// <param name="rules">The parsing rules to use for this content type.</param>
         /// <returns>The parsing result, which includes the roles to add/remove.</returns>
-        Task<LogParsingResult> ReadLog(string logLink, IBatchActorMapper actorMapper);
+        Task<LogParsingResult> ReadLog(string logLink, IBatchActorMapper actorMapper, ILogParsingRules rules);
     }
 }

--- a/src/Prima/Game/FFXIV/FFLogs/Rules/DelubrumReginaeSavageRules.cs
+++ b/src/Prima/Game/FFXIV/FFLogs/Rules/DelubrumReginaeSavageRules.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Prima.Resources;
+using Serilog;
+
+namespace Prima.Game.FFXIV.FFLogs.Rules
+{
+    /// <summary>
+    /// Parsing rules specific to Delubrum Reginae (Savage).
+    /// </summary>
+    public class DelubrumReginaeSavageRules : ILogParsingRules
+    {
+        public ulong FinalClearRoleId => DelubrumProgressionRoles.ClearedDelubrumSavage;
+
+        public string GetProgressionRoleName(string encounterName)
+        {
+            var roleName = encounterName switch
+            {
+                "The Queen's Guard" => "Queen's Guard",
+                _ => encounterName,
+            };
+
+            roleName += " Progression";
+
+            // Validate that this role name exists in our mapping
+            return DelubrumProgressionRoles.Roles.Any(kvp => kvp.Value == roleName) ? roleName : null;
+        }
+
+        public ulong GetKillRoleId(string progressionRoleName)
+        {
+            try
+            {
+                return DelubrumProgressionRoles.GetKillRole(progressionRoleName);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to get kill role for progression role: {ProgressionRole}", progressionRoleName);
+                return 0;
+            }
+        }
+
+        public IEnumerable<ulong> GetContingentRoleIds(ulong killRoleId)
+        {
+            return killRoleId == DelubrumProgressionRoles.ClearedDelubrumSavage
+                ? DelubrumProgressionRoles.Roles.Keys
+                : DelubrumProgressionRoles.GetContingentRoles(killRoleId);
+        }
+
+        public bool ShouldProcessEncounter(int? difficulty)
+        {
+            // DRS Savage encounters have difficulty != 100
+            // Normal mode encounters have difficulty == 100
+            return difficulty != 100;
+        }
+    }
+}

--- a/src/Prima/Game/FFXIV/FFLogs/Rules/ForkedTowerRules.cs
+++ b/src/Prima/Game/FFXIV/FFLogs/Rules/ForkedTowerRules.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace Prima.Game.FFXIV.FFLogs.Rules
+{
+    public class ForkedTowerRules : ILogParsingRules
+    {
+        public ulong FinalClearRoleId => 1381433968431202424;
+
+        public string GetProgressionRoleName(string encounterName)
+        {
+            // TODO: Implement Forked Tower encounter to role mapping
+            return null;
+        }
+
+        public ulong GetKillRoleId(string progressionRoleName)
+        {
+            // TODO: Implement Forked Tower progression to kill role mapping
+            return 0;
+        }
+
+        public IEnumerable<ulong> GetContingentRoleIds(ulong killRoleId)
+        {
+            // TODO: Implement Forked Tower contingent roles logic
+            return new List<ulong>();
+        }
+
+        public bool ShouldProcessEncounter(int? difficulty)
+        {
+            // TODO: Implement Forked Tower difficulty check
+            return false;
+        }
+    }
+}

--- a/src/Prima/Game/FFXIV/FFLogs/Rules/ILogParsingRules.cs
+++ b/src/Prima/Game/FFXIV/FFLogs/Rules/ILogParsingRules.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace Prima.Game.FFXIV.FFLogs.Rules
+{
+    /// <summary>
+    /// Parsing rules specific to different content types.
+    /// </summary>
+    public interface ILogParsingRules
+    {
+        /// <summary>
+        /// Maps encounter names to progression role names.
+        /// </summary>
+        /// <param name="encounterName">The encounter name from the log</param>
+        /// <returns>The progression role name, or null if not applicable</returns>
+        string GetProgressionRoleName(string encounterName);
+
+        /// <summary>
+        /// Gets the kill role information for a progression role.
+        /// </summary>
+        /// <param name="progressionRoleName">The progression role name</param>
+        /// <returns>The kill role ID, or 0 if not found</returns>
+        ulong GetKillRoleId(string progressionRoleName);
+
+        /// <summary>
+        /// Gets all contingent role IDs that should be added when someone gets a kill role.
+        /// </summary>
+        /// <param name="killRoleId">The kill role ID</param>
+        /// <returns>List of role IDs that should also be assigned</returns>
+        IEnumerable<ulong> GetContingentRoleIds(ulong killRoleId);
+
+        /// <summary>
+        /// Determines if an encounter should be processed based on difficulty.
+        /// </summary>
+        /// <param name="difficulty">The difficulty value from the log</param>
+        /// <returns>True if the encounter should be processed</returns>
+        bool ShouldProcessEncounter(int? difficulty);
+
+        /// <summary>
+        /// Gets the final clear role ID (e.g., "DRS Cleared").
+        /// </summary>
+        ulong FinalClearRoleId { get; }
+    }
+}


### PR DESCRIPTION
- Fix ctor to accept `IFFLogsClient` instead of `FFLogsClient`
- Extract DRS-specific parsing logic to `ILogParsingRules` implementation
- Added tests for parsing rules and new parsing service
- Added placeholder for FT parsing logic