### PR TITLE
Correctly remove prog roles when verifying clears

### DIFF
--- a/src/Prima.Application/Community/CrystalExploratoryMissions/CensusCommands.cs
+++ b/src/Prima.Application/Community/CrystalExploratoryMissions/CensusCommands.cs
@@ -8,6 +8,7 @@ using NetStone.Model.Parseables.Character.Achievement;
 using Prima.DiscordNet;
 using Prima.DiscordNet.Attributes;
 using Prima.Game.FFXIV;
+using Prima.Game.FFXIV.FFLogs.Rules;
 using Prima.Models;
 using Prima.Resources;
 using Prima.Services;
@@ -763,8 +764,8 @@ public class CensusCommands : ModuleBase<SocketCommandContext>
         {
             await AddAchievementRole(clearedDrs, member);
 
-            var queenProg = guild.Roles.FirstOrDefault(r => r.Name == "The Queen Progression");
-            var contingentRoles = DelubrumProgressionRoles.GetContingentRoles(queenProg?.Id ?? 0);
+            var fightRules = new DelubrumReginaeSavageRules();
+            var contingentRoles = fightRules.GetContingentRoleIds(fightRules.FinalClearRoleId);
             foreach (var crId in contingentRoles)
             {
                 var cr = guild.GetRole(crId);
@@ -787,6 +788,17 @@ public class CensusCommands : ModuleBase<SocketCommandContext>
             achievements.Any(achievement => achievement.Id == 3668)) // A Fork To Be Reckoned With I
         {
             await AddAchievementRole(clearedForkedTower, member);
+
+            var fightRules = new ForkedTowerRules();
+            var contingentRoles = fightRules.GetContingentRoleIds(fightRules.FinalClearRoleId);
+            foreach (var crId in contingentRoles)
+            {
+                var cr = guild.GetRole(crId);
+                if (!member.HasRole(cr)) continue;
+                await member.RemoveRoleAsync(cr);
+                _logger.LogInformation("Role {RoleName} removed from {DiscordName}", cr.Name, member.ToString());
+            }
+
             hasForkedTowerBloodAchievement1 = true;
         }
 

--- a/src/Prima.Tests/DelubrumReginaeSavageRulesTests.cs
+++ b/src/Prima.Tests/DelubrumReginaeSavageRulesTests.cs
@@ -71,6 +71,23 @@ namespace Prima.Tests
         }
 
         [Test]
+        public void GetContingentRoleIds_QueenKill_ReturnsAllProgressionRoles()
+        {
+            var contingentRoles = _rules.GetContingentRoleIds(_rules.FinalClearRoleId).ToList();
+
+            // Should return all progression roles when cleared
+            var expectedRoles = DelubrumProgressionRoles.Roles
+                .Where(kvp => kvp.Value.EndsWith("Progression") && kvp.Value != "debug delub role")
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var expectedRole in expectedRoles)
+            {
+                Assert.That(contingentRoles, Does.Contain(expectedRole));
+            }
+        }
+
+        [Test]
         public void GetContingentRoleIds_QueenProgression_ReturnsAllProgressionRoles()
         {
             var queenRole = DelubrumProgressionRoles.Roles

--- a/src/Prima.Tests/ForkedTowerRulesTests.cs
+++ b/src/Prima.Tests/ForkedTowerRulesTests.cs
@@ -88,6 +88,23 @@ namespace Prima.Tests
         }
 
         [Test]
+        public void GetContingentRoleIds_MagitaurKill_ReturnsAllProgressionRoles()
+        {
+            var contingentRoles = _rules.GetContingentRoleIds(_rules.FinalClearRoleId).ToList();
+
+            // Should return all progression roles when cleared
+            var expectedRoles = ForkedTowerRules.Roles
+                .Where(kvp => kvp.Value.EndsWith("Progression"))
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var expectedRole in expectedRoles)
+            {
+                Assert.That(contingentRoles, Does.Contain(expectedRole));
+            }
+        }
+
+        [Test]
         public void GetContingentRoleIds_DemonTabletProgression_ReturnsSelfOnly()
         {
             var demonTabletRole = ForkedTowerRules.Roles

--- a/src/Prima/Game/FFXIV/FFLogs/LogParserService.cs
+++ b/src/Prima/Game/FFXIV/FFLogs/LogParserService.cs
@@ -132,7 +132,7 @@ namespace Prima.Game.FFXIV.FFLogs
                                 RoleId = progRoleId,
                             }));
 
-                        // Give everyone the clear role if they cleared DRS
+                        // Add the clear role
                         roleActions.Add(new LogParsingResult.RoleAction
                         {
                             ActionType = LogParsingResult.RoleActionType.Add,
@@ -173,6 +173,7 @@ namespace Prima.Game.FFXIV.FFLogs
             {
                 RoleAssignments = roleAssignments,
                 MissedUsers = missedUsers,
+                Rules = rules,
             };
         }
 

--- a/src/Prima/Game/FFXIV/FFLogs/Rules/ForkedTowerRules.cs
+++ b/src/Prima/Game/FFXIV/FFLogs/Rules/ForkedTowerRules.cs
@@ -44,6 +44,7 @@ namespace Prima.Game.FFXIV.FFLogs.Rules
             var baseList = new[] { MagitaurProgression, MarbleDragonProgression, DeadStarsProgression, DemonTabletProgression };
             return roleId switch
             {
+                ClearedForkedTower => baseList,
                 MagitaurProgression => baseList,
                 MarbleDragonProgression => baseList[1..],
                 DeadStarsProgression => baseList[2..],

--- a/src/Prima/Models/FFLogs/LogParsingResult.cs
+++ b/src/Prima/Models/FFLogs/LogParsingResult.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Prima.Game.FFXIV;
+using Prima.Game.FFXIV.FFLogs.Rules;
 
 namespace Prima.Models.FFLogs
 {
@@ -18,6 +19,7 @@ namespace Prima.Models.FFLogs
             public List<UserRoleAssignment> RoleAssignments { get; init; } = new();
             public List<LogInfo.ReportDataWrapper.ReportData.Report.Master.Actor> MissedUsers { get; init; } = new();
             public bool HasAnyChanges => RoleAssignments.Count > 0;
+            public ILogParsingRules Rules { get; init; }
         }
 
         public class Failure : LogParsingResult


### PR DESCRIPTION
- Include `GetContingentRoleIds` handling for FT clear role
- Return selected ruleset to be able to check if someone has already cleared before assigning new prog roles
- Remove FT prog roles after verifying a clear with `~verify`