### PR TITLE
Fix FT roles not being assigned sometimes

### DIFF
--- a/src/Prima/Game/FFXIV/FFLogs/Rules/DefaultLogParsingRulesSelector.cs
+++ b/src/Prima/Game/FFXIV/FFLogs/Rules/DefaultLogParsingRulesSelector.cs
@@ -11,6 +11,11 @@ namespace Prima.Game.FFXIV.FFLogs.Rules
         {
             foreach (var encounter in report.Fights)
             {
+                if (string.IsNullOrWhiteSpace(encounter.Name))
+                {
+                    continue;
+                }
+
                 if (DelubrumProgressionRoles.Roles.Values.Any(roleName => roleName.Contains(encounter.Name)))
                 {
                     return new DelubrumReginaeSavageRules();


### PR DESCRIPTION
In DefaultLogParsingRulesSelector, we go through the fight names to see which content we need to check prog for. We do this by comparing fight names to role names, since the role names all have the fight name in them. However, fight names can sometimes be empty, in which case they'll always match any string. This had the unfortunate effect of always marking affected logs as DRS fights, since that gets checked before FT.

This commit fixes the issue by skipping fights with empty/whitespace names.

Also added more logging to make it easier to identify these issues in the future.